### PR TITLE
Hello, please add my changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "minimist": "^1.2.0",
     "moment": "^2.11.2",
     "x2js": "^2.0.0",
-    "xmldom": "^0.1.22"
+    "xmldom": "^0.1.22",
+    "flat": "^2.0.1"
   },
   "devDependencies": {
     "browserify": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-man",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "Multiple weather providers in one spot",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-man",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Multiple weather providers in one spot",
   "main": "index.js",
   "repository": {

--- a/providers/forecastio.js
+++ b/providers/forecastio.js
@@ -2,6 +2,7 @@ var axios = require('axios');
 var CurrentResult = require('../results/currentResult');
 var MalformedResponse = require('../utils/exceptions').MalformedResponse;
 var constants = require('../utils/constants');
+var results = require('../utils/results');
 
 function condition(code) {
     var returnCode = constants.CLEAR;
@@ -27,6 +28,29 @@ function condition(code) {
     }
 
     return returnCode;
+}
+
+function flatResults(res) {
+
+    var map = {};
+
+    map[constants.LAT] = 'latitude';
+    map[constants.LON] = 'longitude';
+    map[constants.TEMP] = 'currently.temperature';
+    map[constants.MAX] = '_temp_max';
+    map[constants.MIN] = '_temp_min';
+    map[constants.CODE] = 'currently.icon';
+    map[constants.SUMMARY] = 'currently.summary';
+    map[constants.HUMIDITY] = 'currently.humidity';
+    map[constants.PRESSURE] = 'currently.pressure';
+    map[constants.VISIBILITY] = 'currently.visibility';
+    map[constants.SUNRISE] = '_sunrise';
+    map[constants.SUNSET] = '_sunset';
+    map[constants.WIND_SPEED] = 'currently.windSpeed';
+    map[constants.WIND_DIR] = 'currently.windBearing';
+    map[constants.FEELS_LIKE] = 'currently.apparentTemperature';
+
+    return results.mapResults(res, map);
 }
 
 function convertTime(timestamp) {
@@ -56,6 +80,13 @@ function getCurrent(lat, lng, apiKey) {
                 result.setSunrise(convertTime(current.sunriseTime));
                 result.setSunset(convertTime(current.sunsetTime));
             }
+
+            res.data._sunrise = res.data._sunrise || current.sunriseTime;
+            res.data._sunset = res.data._sunset || current.sunsetTime;
+            res.data._temp_max = res.data._temp_max || current.temperatureMax;
+            res.data._temp_min = res.data._temp_min || current.temperatureMin;
+
+            result.setFullResults(flatResults(res.data));
         }
         else {
             throw new MalformedResponse(constants.OPENWEATHERMAP);

--- a/providers/openweathermap.js
+++ b/providers/openweathermap.js
@@ -2,6 +2,7 @@ var axios = require('axios');
 var CurrentResult = require('../results/currentResult');
 var MalformedResponse = require('../utils/exceptions').MalformedResponse;
 var constants = require('../utils/constants');
+var results = require('../utils/results');
 
 function condition(code) {
     var returnCode = constants.CLEAR;
@@ -51,6 +52,28 @@ function condition(code) {
     return returnCode;
 }
 
+function flatResults(res) {
+
+    var map = {};
+
+    map[constants.LAT] = 'coord.lat';
+    map[constants.LON] = 'coord.lon';
+    map[constants.TEMP] = 'main.temp';
+    map[constants.MAX] = 'main.temp_max';
+    map[constants.MIN] = 'main.temp_min';
+    map[constants.CODE] = 'weather.0.id';
+    map[constants.SUMMARY] = 'weather.0.main';
+    map[constants.HUMIDITY] = 'main.humidity';
+    map[constants.PRESSURE] = 'main.pressure';
+    map[constants.VISIBILITY] = 'visibility.value';
+    map[constants.SUNRISE] = 'sys.sunrise';
+    map[constants.SUNSET] = 'sys.sunset';
+    map[constants.WIND_SPEED] = 'wind.speed';
+    map[constants.WIND_DIR] = 'wind.deg';
+
+    return results.mapResults(res, map);
+}
+
 function convertTime(timestamp) {
     var date = new Date(timestamp * 1000);
     return date.getHours() * 60 + date.getMinutes();
@@ -68,6 +91,7 @@ function getCurrent(lat, lng, apiKey) {
             result.setSunset(convertTime(res.data.sys.sunset));
             result.setHumidity(res.data.main.humidity);
             result.setWindSpeed(res.data.wind.speed, constants.KILOMETERS);
+            result.setFullResults(flatResults(res.data));
         }
         else {
             throw new MalformedResponse(constants.OPENWEATHERMAP);

--- a/providers/yahoo.js
+++ b/providers/yahoo.js
@@ -2,6 +2,7 @@ var axios = require('axios');
 var CurrentResult = require('../results/currentResult');
 var MalformedResponse = require('../utils/exceptions').MalformedResponse;
 var constants = require('../utils/constants');
+var results = require('../utils/results');
 
 function condition(code) {
     var returnCode = constants.CLEAR;
@@ -54,6 +55,26 @@ function condition(code) {
     return returnCode;
 }
 
+function flatResults(res) {
+
+    var map = {};
+
+    map[constants.LAT] = 'item.lat';
+    map[constants.LON] = 'item.long';
+    map[constants.TEMP] = 'item.condition.temp';
+    map[constants.CODE] = 'item.condition.code';
+    map[constants.SUMMARY] = 'item.condition.text';
+    map[constants.HUMIDITY] = 'atmosphere.humidity';
+    map[constants.PRESSURE] = 'atmosphere.pressure';
+    map[constants.VISIBILITY] = 'atmosphere.visibility';
+    map[constants.SUNRISE] = 'astronomy.sunrise';
+    map[constants.SUNSET] = 'astronomy.sunset';
+    map[constants.WIND_SPEED] = 'wind.speed';
+    map[constants.WIND_DIR] = 'wind.direction';
+
+    return results.mapResults(res, map);
+}
+
 function convertTime(string) {
     string = string.toLowerCase();
     var time = string.replace('am', '').replace('pm', '').replace(' ', '');
@@ -104,6 +125,7 @@ function getCurrent(lat, lng) {
                 result.setSunrise(convertTime(data.astronomy.sunrise));
                 result.setSunset(convertTime(data.astronomy.sunset));
                 result.setHumidity(data.atmosphere.humidity);
+                result.setFullResults(flatResults(data));
             }
             else {
                 throw new MalformedResponse(constants.YAHOO);

--- a/providers/yrno.js
+++ b/providers/yrno.js
@@ -4,6 +4,7 @@ var X2JS = require('x2js');
 var CurrentResult = require('../results/currentResult');
 var MalformedResponse = require('../utils/exceptions').MalformedResponse;
 var constants = require('../utils/constants');
+var results = require('../utils/results');
 
 //Reference: http://api.yr.no/weatherapi/weathericon/1.1/documentation
 function condition(code) {
@@ -62,6 +63,25 @@ function condition(code) {
     }
 
     return returnCode;
+}
+
+function flatResults(res) {
+
+    var map = {};
+
+    map[constants.LAT] = '_latitude';
+    map[constants.LON] = '_longitude';
+    map[constants.TEMP] = 'temperature._value';
+    map[constants.CODE] = 'symbol._number';
+    map[constants.SUMMARY] = 'symbol._id';
+    map[constants.HUMIDITY] = 'humidity._value';
+    map[constants.PRESSURE] = 'pressure._value';
+    map[constants.SUNRISE] = '_sunrise';
+    map[constants.SUNSET] = '_sunset';
+    map[constants.WIND_SPEED] = 'windSpeed._mps';
+    map[constants.WIND_DIR] = 'windDirection._deg';
+
+    return results.mapResults(res, map);
 }
 
 function convertTime(timestamp) {
@@ -159,8 +179,15 @@ function getCurrent(lat, lng, apiKey, getSunrise) {
                             result.setSunset(convertTime(sjson.astrodata.time.location.sun._set));
                         }
 
+                        fullWeather.location._sunrise = fullWeather.location._sunrise || sjson.astrodata.time.location.sun._rise;
+                        fullWeather.location._sunset = fullWeather.location._sunset || sjson.astrodata.time.location.sun._set;
+
+                        result.setFullResults(flatResults(fullWeather.location));
+
                         return result;
                     });
+                } else {
+                    result.setFullResults(flatResults(fullWeather.location));
                 }
             }
             else {

--- a/results/currentResult.js
+++ b/results/currentResult.js
@@ -10,6 +10,7 @@ var CurrentResult = function() {
     this.humidity = 0;
     this.sunrise = 1;
     this.sunset = 0;
+    this.fullResults = {};
 };
 
 CurrentResult.prototype.setTemperature = function(temp, units) {
@@ -36,6 +37,10 @@ CurrentResult.prototype.setSunrise = function(sunrise) {
 
 CurrentResult.prototype.setSunset = function(sunset) {
     this.sunset = (sunset === null || sunset === undefined) ? 0 : parseInt(sunset);
+};
+
+CurrentResult.prototype.setFullResults = function(results) {
+    this.fullResults = results || {};
 };
 
 CurrentResult.prototype.getTemperature = function(units) {
@@ -147,6 +152,10 @@ CurrentResult.prototype.getHeatIndex = function(units) {
     }
 
     return convert.temperature(heatIndex, constants.FAHRENHEIT, units);
+};
+
+CurrentResult.prototype.getFullResults = function() {
+    return this.fullResults;
 };
 
 module.exports = CurrentResult;

--- a/results/currentResult.js
+++ b/results/currentResult.js
@@ -43,8 +43,8 @@ CurrentResult.prototype.setFullResults = function(results) {
     this.fullResults = results || {};
 };
 
-CurrentResult.prototype.getTemperature = function(units) {
-    return convert.temperature(this.temperature, this.temperatureUnits, units);
+CurrentResult.prototype.getTemperature = function(units, temp) {
+    return convert.temperature(temp || this.temperature, this.temperatureUnits, units);
 };
 
 CurrentResult.prototype.getWindSpeed = function(units) {

--- a/results/currentResult.js
+++ b/results/currentResult.js
@@ -64,7 +64,7 @@ CurrentResult.prototype.minutesToDate = function(time) {
     var hours = Math.round((time - minutes) / 60);
 
     var date = new Date();
-    date.setHours(hour);
+    date.setHours(hours);
     date.setMinutes(minutes);
 
     return date;

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -30,4 +30,22 @@ module.exports = {
     EXTREME_COLD: 'extreme cold',
     EXTREME_HEAT: 'extreme cold',
     SNOW_THUNDERSTORM: 'snow thunderstorm',
+
+// flat result object keys
+
+    LAT: 'lat',
+    LON: 'lon',
+    TEMP: 'temp',
+    MAX: 'max',
+    MIN: 'min',
+    CODE: 'code',
+    SUMMARY: 'summary',
+    HUMIDITY: 'humidity',
+    PRESSURE: 'pressure',
+    VISIBILITY: 'visibility',
+    SUNRISE: 'sunrise',
+    SUNSET: 'sunset',
+    WIND_SPEED: 'windSpeed',
+    WIND_DIR: 'windDir',
+    FEELS_LIKE: 'feelsLike'
 };

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -28,7 +28,7 @@ module.exports = {
     TORNADO: 'tornado',
     HURRICANE: 'hurricane',
     EXTREME_COLD: 'extreme cold',
-    EXTREME_HEAT: 'extreme cold',
+    EXTREME_HEAT: 'extreme heat',
     SNOW_THUNDERSTORM: 'snow thunderstorm',
 
 // flat result object keys

--- a/utils/results.js
+++ b/utils/results.js
@@ -1,0 +1,11 @@
+var flatten = require('flat');
+
+module.exports.mapResults = function(res, map) {
+
+    var fl = flatten(res, { safe: false });
+
+    return Object.keys(map).reduce(function(prev, curr) {
+        prev[curr] = map[curr] && fl[map[curr]];
+        return prev;
+    }, {});
+};


### PR DESCRIPTION
Changes includes ability to get more complex result's object, in format unified for all providers. So, you'll be able to do this:

`result.getFullResults()`

and get something like this:

`{ lat: 56.31,
  lon: 44.02,
  temp: 20.51,
  max: 21,
  min: 20,
  code: 802,
  summary: 'Clouds',
  humidity: 68,
  pressure: 1006,
  sunrise: 1467937676,
  sunset: 1468000169,
  windSpeed: 4,
  windDir: 160 }`

object with identical fields regardless of provider. Thanks!
